### PR TITLE
fix: fix priority queue crash after using To_list

### DIFF
--- a/lib/priorityQueue/priorityQueue.go
+++ b/lib/priorityQueue/priorityQueue.go
@@ -2,6 +2,7 @@ package priorityQueue
 
 import (
 	"container/heap"
+
 	"github.com/khorcarol/AgentOfThings/lib/option"
 )
 
@@ -112,7 +113,7 @@ func (pq *PriorityQueue[T]) Remove(val T) {
 	*pq = n
 }
 
-func (pq PriorityQueue[T]) To_list() []T {
+func (pq *PriorityQueue[T]) To_list() []T {
 	res := make([]T, pq.Len())
 
 	for i := 0; i < pq.Len(); i++ {

--- a/lib/priorityQueue/priorityQueue_test.go
+++ b/lib/priorityQueue/priorityQueue_test.go
@@ -1,8 +1,9 @@
 package priorityQueue
 
 import (
-	"github.com/khorcarol/AgentOfThings/lib/option"
 	"testing"
+
+	"github.com/khorcarol/AgentOfThings/lib/option"
 )
 
 func Test_pops_correct_order(t *testing.T) {
@@ -88,5 +89,17 @@ func Test_updates_item(t *testing.T) {
 	}
 	if v3 != 1 {
 		t.Errorf("Fail on %s: First pop meant to be 1, got: %d", t.Name(), v1)
+	}
+}
+
+func Test_to_list(t *testing.T) {
+	pq := NewPriorityQueue[int]()
+
+	pq.Push(1, 1)
+
+	_ = pq.To_list()
+
+	if pq.Len() != 0 {
+		t.Errorf("Fail on %s: Priority queue length should be 0: %d", t.Name(), pq.Len())
 	}
 }


### PR DESCRIPTION
To_list modifies the queue and pops all values, so we need to pass the instance as a pointer. Otherwise, To_list results in a broken queue which crashes when Remove is used on it.

Regression test included