### PR TITLE
fix: ignore image field for serialisation

### DIFF
--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -24,7 +24,7 @@ type User struct {
 // A [Friend] is a [User] who we have requested to be friends with, and who has also requested to be friends with us.
 type Friend struct {
 	User  User
-	Photo image.Image
+	Photo image.Image `json:"-"`
 	Name  string
 }
 


### PR DESCRIPTION
This fails during deserialisation because go doesn't know how to handle this type. We can tell Marshal/Unmarshal to ignore this field by setting its json name to `-`. Refer to the json.Marshal documentation:

https://pkg.go.dev/encoding/json#Marshal

This is a quick fix until #87 can be resolved properly.