### PR TITLE
feat: allow setting profile sub directory

### DIFF
--- a/internal/personal/personal.go
+++ b/internal/personal/personal.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/khorcarol/AgentOfThings/internal/api"
 	"github.com/khorcarol/AgentOfThings/internal/sources"
+	"github.com/khorcarol/AgentOfThings/internal/storage"
 )
 
 var self api.Friend
@@ -29,8 +30,8 @@ func GetSelf() api.Friend {
 
 func getCandidatePaths() []string {
 	var paths []string
-	if cachePath, err := os.UserCacheDir(); err == nil {
-		paths = append(paths, filepath.Join(cachePath, "AgentOfThings", "profile", "profilePicture.png"))
+	if cachePath, err := storage.GetCacheDir(); err == nil {
+		paths = append(paths, filepath.Join(cachePath, "profile", "profilePicture.png"))
 	}
 	paths = append(paths, filepath.Join("assets", "blank-profile.png"))
 	return paths

--- a/internal/personal/personal.go
+++ b/internal/personal/personal.go
@@ -14,7 +14,7 @@ import (
 
 var self api.Friend
 
-func init() {
+func Init() {
 	uuid, _ := GetUUID()
 	id := api.ID{Address: uuid}
 	interests := sources.GetInterests()

--- a/internal/personal/uuid.go
+++ b/internal/personal/uuid.go
@@ -9,11 +9,11 @@ import (
 	"sync"
 
 	"github.com/google/uuid"
+	"github.com/khorcarol/AgentOfThings/internal/storage"
 )
 
 const (
-	appCacheDirName = "AgentOfThings"
-	uuidFileName    = "uuid.json"
+	uuidFileName = "uuid.json"
 )
 
 type uuidConfig struct {
@@ -40,13 +40,12 @@ func GetUUID() (uuid.UUID, error) {
 // getUUIDInternal reads the UUID from the appdata cache file, or creates a cache file if not found.
 func getUUIDInternal() (uuid.UUID, error) {
 	// Obtain the platform-specific configuration directory.
-	cacheDir, err := os.UserCacheDir()
+	cacheDir, err := storage.GetCacheDir()
 	if err != nil {
 		return uuid.Nil, fmt.Errorf("failed to get user cache dir: %w", err)
 	}
 
-	appConfigPath := filepath.Join(cacheDir, appCacheDirName)
-	uuidFilePath := filepath.Join(appConfigPath, uuidFileName)
+	uuidFilePath := filepath.Join(cacheDir, uuidFileName)
 
 	if info, err := os.Stat(uuidFilePath); err == nil && !info.IsDir() {
 		// File exists; read and unmarshal the stored UUID.
@@ -70,10 +69,6 @@ func getUUIDInternal() (uuid.UUID, error) {
 	} else if err != nil && !os.IsNotExist(err) {
 		// Shouldn't happen if the OS plays ball.
 		return uuid.Nil, fmt.Errorf("failed to check for UUID file: %w", err)
-	}
-
-	if err := os.MkdirAll(appConfigPath, 0755); err != nil {
-		return uuid.Nil, fmt.Errorf("failed to create config directory: %w", err)
 	}
 
 	newUUID := uuid.New()

--- a/internal/sources/cache.go
+++ b/internal/sources/cache.go
@@ -9,15 +9,16 @@ import (
 	"time"
 
 	"github.com/khorcarol/AgentOfThings/internal/api"
+	"github.com/khorcarol/AgentOfThings/internal/storage"
 )
 
 func getSourceCacheFileName(sourceName string) (string, error) {
-	cachePath, err := os.UserCacheDir()
+	cachePath, err := storage.GetCacheDir()
 	if err != nil {
 		return "", err
 	}
 
-	path := filepath.Join(cachePath, "AgentOfThings", "sources", sourceName+".json")
+	path := filepath.Join(cachePath, "sources", sourceName+".json")
 
 	return path, nil
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	appDirName      = "agentofthings"
+	appDirName      = "AgentOfThings"
 	friendsFileName = "friends.json"
 )
 

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -18,12 +18,17 @@ const (
 // dirProvider interface for getting system directories
 type dirProvider interface {
 	GetConfigDir() (string, error)
+	GetCacheDir() (string, error)
 }
 
 // defaultDirProvider implements dirProvider
 type defaultDirProvider struct{}
 
 func (p defaultDirProvider) GetConfigDir() (string, error) {
+	return os.UserConfigDir()
+}
+
+func (p defaultDirProvider) GetCacheDir() (string, error) {
 	return os.UserConfigDir()
 }
 
@@ -40,6 +45,20 @@ func GetStorageDir() (string, error) {
 	storageDir := filepath.Join(configDir, appDirName)
 	if err := os.MkdirAll(storageDir, 0755); err != nil {
 		return "", fmt.Errorf("failed to create storage directory: %w", err)
+	}
+
+	return storageDir, nil
+}
+
+func GetCacheDir() (string, error) {
+	configDir, err := provider.GetCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get cache directory: %w", err)
+	}
+
+	storageDir := filepath.Join(configDir, appDirName)
+	if err := os.MkdirAll(storageDir, 0755); err != nil {
+		return "", fmt.Errorf("failed to create cache directory: %w", err)
 	}
 
 	return storageDir, nil

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -35,6 +35,12 @@ func (p defaultDirProvider) GetCacheDir() (string, error) {
 // concrete implementation of dirProvider
 var provider dirProvider = defaultDirProvider{}
 
+var profileSubdirectory *string
+
+func SetProfileSubdirectory(subdir string) {
+	profileSubdirectory = &subdir
+}
+
 // returns directory where data should be stored
 func GetStorageDir() (string, error) {
 	configDir, err := provider.GetConfigDir()
@@ -43,6 +49,10 @@ func GetStorageDir() (string, error) {
 	}
 
 	storageDir := filepath.Join(configDir, appDirName)
+	if profileSubdirectory != nil {
+		storageDir = filepath.Join(storageDir, *profileSubdirectory)
+	}
+
 	if err := os.MkdirAll(storageDir, 0755); err != nil {
 		return "", fmt.Errorf("failed to create storage directory: %w", err)
 	}
@@ -57,6 +67,10 @@ func GetCacheDir() (string, error) {
 	}
 
 	storageDir := filepath.Join(configDir, appDirName)
+	if profileSubdirectory != nil {
+		storageDir = filepath.Join(storageDir, *profileSubdirectory)
+	}
+
 	if err := os.MkdirAll(storageDir, 0755); err != nil {
 		return "", fmt.Errorf("failed to create cache directory: %w", err)
 	}

--- a/main.go
+++ b/main.go
@@ -1,10 +1,27 @@
 package main
 
 import (
+	"log"
+	"os"
+
 	"github.com/khorcarol/AgentOfThings/frontend"
+	"github.com/khorcarol/AgentOfThings/internal/personal"
+	"github.com/khorcarol/AgentOfThings/internal/storage"
 )
 
 func main() {
+	for i, arg := range os.Args {
+		if arg == "--profile" {
+			if len(os.Args) > i+1 {
+				log.Println("hello")
+				storage.SetProfileSubdirectory(os.Args[i+1])
+			} else {
+				log.Fatalf("%s must have a value", arg)
+			}
+		}
+	}
+
+	personal.Init()
 	frontend.Init()
 	frontend.Main()
 }

--- a/main.go
+++ b/main.go
@@ -13,7 +13,6 @@ func main() {
 	for i, arg := range os.Args {
 		if arg == "--profile" {
 			if len(os.Args) > i+1 {
-				log.Println("hello")
 				storage.SetProfileSubdirectory(os.Args[i+1])
 			} else {
 				log.Fatalf("%s must have a value", arg)


### PR DESCRIPTION
This adds an optional `--profile` command line argument so the app can be run with a different profile directory.

Example usage:
```
./AgentOfThings --profile user1
```

This is useful when testing multiple instances of the app on the same device.

Closes #99