### PR TITLE
fix: use correct storage paths for android

### DIFF
--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -12,7 +12,6 @@ import (
 )
 
 const (
-	appDirName       = "AgentOfThings"
 	friendsFileName  = "friends.json"
 	personalFileName = "personal.json"
 )
@@ -25,12 +24,11 @@ func SetProfileSubdirectory(subdir string) {
 
 // returns directory where data should be stored
 func GetStorageDir() (string, error) {
-	configDir, err := os.UserConfigDir()
+	storageDir, err := getAppConfigDir()
 	if err != nil {
-		return "", fmt.Errorf("failed to get config directory: %w", err)
+		return "", err
 	}
 
-	storageDir := filepath.Join(configDir, appDirName)
 	if profileSubdirectory != nil {
 		storageDir = filepath.Join(storageDir, *profileSubdirectory)
 	}
@@ -43,21 +41,20 @@ func GetStorageDir() (string, error) {
 }
 
 func GetCacheDir() (string, error) {
-	configDir, err := os.UserCacheDir()
+	cacheDir, err := getAppCacheDir()
 	if err != nil {
-		return "", fmt.Errorf("failed to get cache directory: %w", err)
+		return "", err
 	}
 
-	storageDir := filepath.Join(configDir, appDirName)
 	if profileSubdirectory != nil {
-		storageDir = filepath.Join(storageDir, *profileSubdirectory)
+		cacheDir = filepath.Join(cacheDir, *profileSubdirectory)
 	}
 
-	if err := os.MkdirAll(storageDir, 0755); err != nil {
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
 		return "", fmt.Errorf("failed to create cache directory: %w", err)
 	}
 
-	return storageDir, nil
+	return cacheDir, nil
 }
 
 // serializes and writes friends map to disk

--- a/internal/storage/storage_dirs.go
+++ b/internal/storage/storage_dirs.go
@@ -1,0 +1,30 @@
+//go:build !android
+// +build !android
+
+package storage
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const appDirName = "AgentOfThings"
+
+func getAppCacheDir() (string, error) {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get cache directory: %w", err)
+	}
+
+	return filepath.Join(cacheDir, appDirName), nil
+}
+
+func getAppConfigDir() (string, error) {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get config directory: %w", err)
+	}
+
+	return filepath.Join(configDir, appDirName), nil
+}

--- a/internal/storage/storage_dirs_android.go
+++ b/internal/storage/storage_dirs_android.go
@@ -1,0 +1,16 @@
+//go:build android
+// +build android
+
+package storage
+
+import "path/filepath"
+
+const appDirectory = "/data/data/com.groupalpha.agentofthings"
+
+func getAppCacheDir() (string, error) {
+	return filepath.Join(appDirectory, "cache"), nil
+}
+
+func getAppConfigDir() (string, error) {
+	return filepath.Join(appDirectory, "files"), nil
+}


### PR DESCRIPTION
os.UserConfigDir() and os.UserCacheDir return errors on Android due to undefined HOME environment variable.

`/data/data/com.groupalpha.agentofthings` seems to be the correct path to store data on android