### PR TITLE
fix: avoid missing image breaking user layout

### DIFF
--- a/frontend/fyne.go
+++ b/frontend/fyne.go
@@ -184,9 +184,13 @@ func createUsersUI() fyne.CanvasObject {
 			nameLabel.TextSize = 16
 
 			return container.NewVBox(
-				nameLabel,
-				widget.NewLabel("Interests: "),
-				image,
+				container.NewHBox(
+					container.NewVBox(
+						nameLabel,
+						widget.NewLabel("Interests: "),
+					),
+					container.NewPadded(image),
+				),
 				widget.NewButton("Send Friend Request", nil),
 				widget.NewButton("Reject Friend Request", nil),
 			)
@@ -195,11 +199,13 @@ func createUsersUI() fyne.CanvasObject {
 			user := currentUsers[i]
 			container := o.(*fyne.Container)
 
-			interests_label := container.Objects[1].(*widget.Label)
+			topContainer := container.Objects[0].(*fyne.Container)
+
+			interests_label := topContainer.Objects[0].(*fyne.Container).Objects[1].(*widget.Label)
 			interests_label.Text = "Interests: \n" + formatInterests(user.Interests)
 			interests_label.Refresh()
 
-			image := container.Objects[2].(*canvas.Image)
+			image := topContainer.Objects[1].(*fyne.Container).Objects[0].(*canvas.Image)
 			if imageUrl := getImage(user.Interests); imageUrl != nil {
 				image.Show()
 				image.Resource, _ = fyne.LoadResourceFromURLString(*imageUrl)
@@ -208,14 +214,14 @@ func createUsersUI() fyne.CanvasObject {
 				image.Hide()
 			}
 
-			friendButton := container.Objects[3].(*widget.Button)
+			friendButton := container.Objects[1].(*widget.Button)
 
 			friendButton.OnTapped = func() {
 				middle.Seen(user.UserID)
 				middle.SendFriendRequest(user.UserID, true)
 			}
 
-			rejectButton := container.Objects[4].(*widget.Button)
+			rejectButton := container.Objects[2].(*widget.Button)
 
 			rejectButton.OnTapped = func() {
 				middle.Seen(user.UserID)

--- a/frontend/fyne.go
+++ b/frontend/fyne.go
@@ -189,6 +189,7 @@ func createUsersUI() fyne.CanvasObject {
 						nameLabel,
 						widget.NewLabel("Interests: "),
 					),
+					layout.NewSpacer(),
 					container.NewPadded(image),
 				),
 				widget.NewButton("Send Friend Request", nil),
@@ -205,7 +206,7 @@ func createUsersUI() fyne.CanvasObject {
 			interests_label.Text = "Interests: \n" + formatInterests(user.Interests)
 			interests_label.Refresh()
 
-			image := topContainer.Objects[1].(*fyne.Container).Objects[0].(*canvas.Image)
+			image := topContainer.Objects[2].(*fyne.Container).Objects[0].(*canvas.Image)
 			if imageUrl := getImage(user.Interests); imageUrl != nil {
 				image.Show()
 				image.Resource, _ = fyne.LoadResourceFromURLString(*imageUrl)

--- a/frontend/fyne.go
+++ b/frontend/fyne.go
@@ -192,6 +192,7 @@ func createUsersUI() fyne.CanvasObject {
 					layout.NewSpacer(),
 					container.NewPadded(image),
 				),
+				layout.NewSpacer(),
 				widget.NewButton("Send Friend Request", nil),
 				widget.NewButton("Reject Friend Request", nil),
 			)
@@ -215,14 +216,14 @@ func createUsersUI() fyne.CanvasObject {
 				image.Hide()
 			}
 
-			friendButton := container.Objects[1].(*widget.Button)
+			friendButton := container.Objects[2].(*widget.Button)
 
 			friendButton.OnTapped = func() {
 				middle.Seen(user.UserID)
 				middle.SendFriendRequest(user.UserID, true)
 			}
 
-			rejectButton := container.Objects[2].(*widget.Button)
+			rejectButton := container.Objects[3].(*widget.Button)
 
 			rejectButton.OnTapped = func() {
 				middle.Seen(user.UserID)

--- a/frontend/fyne.go
+++ b/frontend/fyne.go
@@ -179,8 +179,12 @@ func createUsersUI() fyne.CanvasObject {
 		func() fyne.CanvasObject {
 			image := &canvas.Image{}
 			image.SetMinSize(fyne.Size{Width: 200, Height: 200})
+
+			nameLabel := canvas.NewText("  Anonymous User", color.Black)
+			nameLabel.TextSize = 16
+
 			return container.NewVBox(
-				canvas.NewText("  Anonymous User", color.Black),
+				nameLabel,
 				widget.NewLabel("Interests: "),
 				image,
 				widget.NewButton("Send Friend Request", nil),
@@ -190,9 +194,6 @@ func createUsersUI() fyne.CanvasObject {
 		func(i widget.ListItemID, o fyne.CanvasObject) {
 			user := currentUsers[i]
 			container := o.(*fyne.Container)
-
-			nameLabel := container.Objects[0].(*canvas.Text)
-			nameLabel.TextSize = 16
 
 			interests_label := container.Objects[1].(*widget.Label)
 			interests_label.Text = "Interests: \n" + formatInterests(user.Interests)


### PR DESCRIPTION
Closes #173

Before:
![image](https://github.com/user-attachments/assets/76a201f4-f1da-4114-afde-48e2f8012fad)


After:
![image](https://github.com/user-attachments/assets/00e88e1d-500e-4e18-9c51-6954e738ac87)
